### PR TITLE
Fix version selection bug

### DIFF
--- a/mod_checker.py
+++ b/mod_checker.py
@@ -573,9 +573,13 @@ def find_common_version(mods: List[ModInfo]) -> Optional[str]:
     if not common_versions:
         return None
         
-    # Sort versions and return the oldest one that's not a snapshot
-    sorted_versions = sort_minecraft_versions([v for v in common_versions if not 'w' in v and not 'snapshot' in v])
-    return sorted_versions[0] if sorted_versions else None
+    # Sort versions in descending order and return the oldest one that's not a snapshot
+    # sort_minecraft_versions returns versions from newest to oldest, so we take
+    # the last element to get the oldest compatible version.
+    sorted_versions = sort_minecraft_versions(
+        [v for v in common_versions if 'w' not in v and 'snapshot' not in v]
+    )
+    return sorted_versions[-1] if sorted_versions else None
 
 def check_loader_compatibility(mods: List[Dict[str, str]], version: str, loader: str) -> Tuple[List[ModInfo], int]:
     """Check how many mods are compatible with a specific loader and version."""

--- a/tests/test_find_common_version.py
+++ b/tests/test_find_common_version.py
@@ -1,0 +1,49 @@
+import unittest
+import sys
+import types
+
+# Provide a minimal stub for the requests module so that mod_checker can be
+# imported without having the real dependency installed.
+sys.modules.setdefault('requests', types.ModuleType('requests'))
+
+# Stub out the 'rich' module hierarchy used in mod_checker so that the module
+# can be imported without the real dependency installed.
+rich_module = types.ModuleType('rich')
+console_module = types.ModuleType('rich.console')
+console_module.Console = object  # simple placeholder
+table_module = types.ModuleType('rich.table')
+table_module.Table = object
+table_module.box = object()
+panel_module = types.ModuleType('rich.panel')
+panel_module.Panel = object
+progress_module = types.ModuleType('rich.progress')
+progress_module.Progress = object
+progress_module.SpinnerColumn = object
+progress_module.TextColumn = object
+progress_module.BarColumn = object
+progress_module.TaskProgressColumn = object
+
+# Minimal stubs for the requests module attributes used in type hints
+requests_module = sys.modules['requests']
+requests_module.Response = object
+requests_module.RequestException = Exception
+
+rich_module.print = print
+sys.modules.setdefault('rich', rich_module)
+sys.modules.setdefault('rich.console', console_module)
+sys.modules.setdefault('rich.table', table_module)
+sys.modules.setdefault('rich.panel', panel_module)
+sys.modules.setdefault('rich.progress', progress_module)
+
+from mod_checker import ModInfo, find_common_version
+
+class TestFindCommonVersion(unittest.TestCase):
+    def test_returns_oldest_version(self):
+        # Create dummy ModInfo objects with available versions
+        mod1 = ModInfo(name='A', slug='a', url='url', versions=['1.19', '1.18'], available=True)
+        mod2 = ModInfo(name='B', slug='b', url='url', versions=['1.19', '1.18'], available=True)
+        # Should return 1.18 (oldest) even though versions sorted descending
+        self.assertEqual(find_common_version([mod1, mod2]), '1.18')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix `find_common_version` to return the oldest compatible version
- add regression test for `find_common_version`

## Testing
- `python -m unittest discover -s tests -v`


------
https://chatgpt.com/codex/tasks/task_e_687243c52b7083238c24440e09a214c4