### PR TITLE
Improve modrinth caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+modrinth_cache/


### PR DESCRIPTION
## Summary
- keep entire version list cached under `{slug}_all`
- reuse cached project info instead of hitting the API repeatedly
- ignore cache and pycache files

## Testing
- `python mod_checker.py --help`
- `python - <<'EOF'
from mod_checker import check_mod_version
result = check_mod_version('sodium', '1.20.1', 'fabric')
print(result)
EOF`
- `python - <<'EOF'
from mod_checker import check_mod_version
result = check_mod_version('sodium', '1.20.1', 'quilt')
print(result.available, result.loader_types)
EOF`
- `python -m py_compile mod_checker.py`

------
https://chatgpt.com/codex/tasks/task_e_68724b7bf97c832387cfa239df58ddf5